### PR TITLE
Prepare 0.0.6 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "markdown-previewer-in-extension-panel",
   "publisher": "nacn",
-  "displayName": "Markdown Preview Panel",
+  "displayName": "Markdown Preview in Extension Panel",
   "description": "Display markdown preview in extension panel",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "icon": "assets/icon-128.png",
   "engines": {
     "vscode": "^1.74.0"


### PR DESCRIPTION
## Summary
- rename the extension display name to "Markdown Preview in Extension Panel"
- bump the extension version to 0.0.6 for the next publish

## Testing
- npm run compile
