### PR TITLE
Add context-aware edit button to markdown preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Display markdown preview in extension panel.
 - Lightweight Markdown preview that stays pinned to the VS Code sidebar or panel
 - Live updates that track the active editor and inherit your current color theme
 - Pin/Unpin button to freeze the preview on the file you care about while you browse others
+- Context-aware `Edit` button that reopens the previewed file when you're focused on a different document
 - Manual `Refresh` command to force a redraw when needed
 - Flexible layout: keep it beside the editor or drag it into the panel for a larger view
 
@@ -19,8 +20,9 @@ Display markdown preview in extension panel.
 1. Open any Markdown file and the "Markdown Preview" view will render it automatically.
 2. Continue editing in the text editor; the preview updates in real time.
 3. Use the pin button to lock the preview to the current Markdown file while you switch editors; click again to resume following the active document.
-4. Use the `Refresh` button in the view toolbar if you want to manually trigger an update.
-5. Drag the view tab into the panel area when you prefer a wider preview.
+4. When the previewed file differs from the editor you're viewing, click `Edit` in the toolbar to jump straight back to that Markdown file.
+5. Use the `Refresh` button in the view toolbar if you want to manually trigger an update.
+6. Drag the view tab into the panel area when you prefer a wider preview.
 
 ## Tips & Known Limitations
 - Images and links render exactly as Markdown resolves them; local paths must be reachable from VS Code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-previewer-in-extension-panel",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-previewer-in-extension-panel",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "markdown-it": "^13.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "nacn",
   "displayName": "Markdown Preview in Extension Panel",
   "description": "Display markdown preview in extension panel",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "icon": "assets/icon-128.png",
   "engines": {
     "vscode": "^1.74.0"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,12 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "markdownPreview.edit",
+        "title": "Edit",
+        "icon": "$(edit)",
+        "enablement": "markdownPreview:canEdit"
+      },
+      {
         "command": "markdownPreview.pin",
         "title": "Pin",
         "icon": "$(pin)",
@@ -60,6 +66,11 @@
     ],
     "menus": {
       "view/title": [
+        {
+          "command": "markdownPreview.edit",
+          "when": "view == markdownPreview && markdownPreview:canEdit",
+          "group": "navigation@0"
+        },
         {
           "command": "markdownPreview.pin",
           "when": "view == markdownPreview && markdownPreview:canPin && !markdownPreview:isPinned",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,12 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     context.subscriptions.push(
+        vscode.commands.registerCommand('markdownPreview.edit', () => {
+            void provider.edit();
+        })
+    );
+
+    context.subscriptions.push(
         vscode.commands.registerCommand('markdownPreview.pin', () => {
             void provider.pin();
         })


### PR DESCRIPTION
## Summary
- show an Edit action in the markdown preview toolbar only when the previewed file differs from the active editor
- open the previewed Markdown in a new editor tab when the button is pressed
- bump the extension to version 0.0.8 and document the new workflow in the README

## Testing
- npm run compile