### PR TITLE
Replace dynamic badges with static badges to fix rate limit error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Markdown Previewer in Extension Area
 
-[![Version](https://img.shields.io/vscode-marketplace/v/nacn.markdown-previewer-in-extension-panel.svg)](https://marketplace.visualstudio.com/items?itemName=nacn.markdown-previewer-in-extension-panel) [![Installs](https://img.shields.io/vscode-marketplace/i/nacn.markdown-previewer-in-extension-panel.svg)](https://marketplace.visualstudio.com/items?itemName=nacn.markdown-previewer-in-extension-panel) [![Rating](https://img.shields.io/vscode-marketplace/r/nacn.markdown-previewer-in-extension-panel.svg)](https://marketplace.visualstudio.com/items?itemName=nacn.markdown-previewer-in-extension-panel)
+[![Version](https://img.shields.io/badge/version-0.5.1-blue)](https://marketplace.visualstudio.com/items?itemName=nacn.markdown-previewer-in-extension-panel) [![VS Code](https://img.shields.io/badge/VS%20Code-1.74.0%2B-blue)](https://code.visualstudio.com/)
 
 A VS Code extension that displays a fully featured Markdown preview in the extension area (primary sidebar, secondary sidebar, or panel) so you can read and navigate your documentation without juggling editor tabs.
 


### PR DESCRIPTION
## Summary
Fixed an issue where shields.io badges in README displayed "rate limited by upstream service" error when viewed in VS Code extension search results.

## Changes
- Removed dynamic badges using VS Code Marketplace API (Version, Installs, Rating)
- Replaced with static badges:
  - Version: 0.5.1 (from package.json)
  - VS Code: 1.74.0+ (minimum requirement)
- Removed Installs and Rating badges (already displayed on Marketplace page)

## Technical Details
shields.io was hitting rate limits when fetching data from VS Code Marketplace API. Switching to static badges that don't require API calls resolves this issue.

## Impact
- README.md only
- No functional changes

## Future Maintenance
When updating the version, the version badge in README.md must be manually updated as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)