### PR TITLE
Add bidirectional scroll sync between editor and preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the "Markdown Preview in Extension Area" extension will b
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-06-13
+
+### Added
+- Bidirectional scroll synchronization between the source Markdown editor and the preview
+  - Scrolling the editor moves the preview to the matching content, and vice versa
+  - Uses source-line anchors (`data-source-line`) injected at render time, mapped
+    via a pure, unit-tested interpolation module (`src/scrollSync.ts`)
+  - New setting `markdownPreviewInExtensionPanel.scrollSync` (boolean, default `true`)
+  - Echo-loop guards on both sides keep editor and preview from fighting each other
+
+### Technical
+- Added 11 unit tests for the scroll-sync mapping functions
+
 ## [1.0.1] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Has four tabs (Outline, Files, History, Help) to view various information.
 | `markdownPreviewInExtensionPanel.defaultZoomLevel` | `100` | Default zoom percentage (50–200) |
 | `markdownPreviewInExtensionPanel.themeMode` | `auto` | Theme mode for the preview (`auto`, `light`, `dark`) |
 | `markdownPreviewInExtensionPanel.fileSortOrder` | `name` | Sort order for files in the Files tab (`name`, `modified`) |
+| `markdownPreviewInExtensionPanel.scrollSync` | `true` | Synchronize scrolling between the source editor and the preview (bidirectional). The source editor must be visible alongside the preview. |
 
 ## Requirements
 - Visual Studio Code 1.74.0 or later

--- a/docs/superpowers/specs/2026-06-13-scroll-sync-design.md
+++ b/docs/superpowers/specs/2026-06-13-scroll-sync-design.md
@@ -1,0 +1,138 @@
+# Scroll Sync Design — Markdown Preview in Extension Area
+
+**Date:** 2026-06-13
+**Status:** Approved (design), pending implementation plan
+
+## Problem
+
+The extension renders Markdown into a webview that lives in its own view
+container (activity bar / panel), separate from the source editor. When the
+source `.md` editor and the preview are placed side by side, their scroll
+positions are independent — scrolling one does not move the other. Users
+editing long documents cannot quickly find the preview region that corresponds
+to the line they are editing (or vice versa).
+
+## Goal
+
+Add **bidirectional scroll synchronization** between the source Markdown editor
+and the preview webview, matching the UX of VS Code's built-in Markdown preview:
+
+- Scrolling the editor moves the preview to the corresponding content.
+- Scrolling the preview moves the editor to the corresponding source line.
+
+## Approach
+
+**Line-anchor mapping** (the same technique VS Code's built-in preview uses).
+At render time, each block element in the preview HTML is tagged with the
+source line number it originated from. Scroll position is translated between
+editor and preview by mapping line numbers to anchor element offsets.
+
+Rejected alternatives:
+- **Percentage-based** (`scrollTop / scrollHeight`): trivial but drifts badly
+  because rendered height does not track source line distribution (e.g. a large
+  Mermaid diagram or image is one source line but a tall rendered block).
+- **Heading-only mapping**: reuses the existing outline anchors but only syncs
+  at section boundaries — coarse and not smooth.
+
+## Architecture
+
+Three cooperating pieces.
+
+### 1. Render-time source-line injection
+
+**Where:** `src/markdownPreviewProvider.ts`, render path around `_md.render()`
+(currently line 410).
+
+Add a small `markdown-it` core rule that walks the parsed token stream and, for
+every top-level block-opening token that carries a `.map` (source line range),
+sets an attribute:
+
+```js
+token.attrSet('data-source-line', String(token.map[0]));
+```
+
+The existing custom `fence` and `image` renderer rules must be updated to
+preserve / emit this attribute so code blocks and images remain anchorable.
+
+Result: each `<p>`, `<h1..6>`, `<pre>`, `<blockquote>`, `<ul>/<ol>`, table,
+etc. in the preview HTML knows which source line it starts at.
+
+### 2. Editor → Preview sync
+
+**Where:** `src/extension.ts` (event subscription) + webview script in
+`getWebviewContent`.
+
+- Subscribe to `vscode.window.onDidChangeTextEditorVisibleRanges`.
+- When the event fires for the editor whose document is the one currently shown
+  in the preview (and the file is not pinned to a different document, and
+  `scrollSync` is enabled, and the echo lock is not held):
+  - Compute the top visible source line from the editor's visible range.
+  - `postMessage({ command: 'syncToLine', line })` to the webview.
+- Webview handler: find the anchor element with the largest
+  `data-source-line <= line` and the next anchor; interpolate the scroll offset
+  between them by the fractional position within the line range; set
+  `scrollTop`.
+
+### 3. Preview → Editor sync
+
+**Where:** webview script (scroll listener) + `onDidReceiveMessage` handler
+(currently line 127).
+
+- Webview listens to its own scroll, debounced (~50ms).
+- Find the top-most anchor element currently in view; derive a fractional
+  source line from its `data-source-line` and the next anchor.
+- `postMessage({ command: 'revealLine', line })`.
+- Extension handler: locate the `TextEditor` for the current document in
+  `vscode.window.visibleTextEditors`; call
+  `editor.revealRange(new vscode.Range(line,0,line,0), TextEditorRevealType.AtTop)`.
+  If no visible editor for that document exists, no-op.
+
+## Key processing concerns
+
+- **Echo / feedback loop prevention.** Editor→preview sync triggers a preview
+  scroll, which would fire preview→editor, which scrolls the editor, etc. Guard
+  with an `isSyncing` lock plus a short timeout (the strategy the built-in
+  preview uses): when one direction is actively driving, suppress the reverse
+  message until the lock clears.
+- **Pin state.** The extension supports pinning the preview to a file. If the
+  preview is pinned to a document different from the active editor, do not sync.
+- **Source editor not visible.** Preview→editor is a no-op when no visible
+  editor shows the current document. Editor→preview resumes naturally once an
+  editor becomes visible and scrolls.
+- **Async-rendered content.** Mermaid diagrams and images change layout height
+  after initial render. Recompute / re-read anchor offsets after render
+  completion (and on resize) rather than caching offsets at render time.
+
+## Configuration
+
+Add one setting, following the existing `markdownPreviewInExtensionPanel.*`
+pattern in `package.json`:
+
+- `markdownPreviewInExtensionPanel.scrollSync` — boolean, default `true`.
+  Enables/disables bidirectional scroll sync.
+
+Direction-specific toggles are intentionally omitted (YAGNI). A single
+on/off switch covers the stated need; finer control can be added later if asked.
+
+## Testing
+
+Automated tests are currently absent in this repo (per AGENTS.md). Verify
+manually in the Extension Host (`F5`):
+
+1. Open a long `.md` in the editor with the preview side by side.
+2. Scroll the editor → preview follows to the matching content.
+3. Scroll the preview → editor follows to the matching source line.
+4. Document mixing headings, paragraphs, code fences, images, and a Mermaid
+   diagram → anchors stay aligned through tall blocks.
+5. Pin the preview to a different file → no sync occurs.
+6. Set `scrollSync` to `false` → both directions stop; setting back to `true`
+   resumes without reload.
+
+If time allows, add a focused unit test for the line→anchor interpolation logic
+(pure function, no VS Code APIs needed) under `src/test/unit/`.
+
+## Out of scope
+
+- Smooth/animated scrolling easing.
+- Direction-specific configuration.
+- Syncing cursor position (only viewport scroll is synced).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-previewer-in-extension-panel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-previewer-in-extension-panel",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "highlight.js": "^11.11.1",
         "markdown-it": "^13.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-previewer-in-extension-panel",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-previewer-in-extension-panel",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "highlight.js": "^11.11.1",
         "markdown-it": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
             "Sort files alphabetically by name",
             "Sort files by modification date (newest first)"
           ]
+        },
+        "markdownPreviewInExtensionPanel.scrollSync": {
+          "type": "boolean",
+          "default": true,
+          "description": "Synchronize scrolling between the source Markdown editor and the preview (bidirectional). The source editor must be visible alongside the preview."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "nacn",
   "displayName": "Markdown Preview in Extension Area",
   "description": "Display markdown preview in sidebar or panel",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "icon": "assets/icon-128.png",
   "engines": {
     "vscode": "^1.74.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,6 +111,14 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    // Editor -> Preview scroll sync: push the editor's top visible line to the
+    // preview whenever its viewport moves.
+    context.subscriptions.push(
+        vscode.window.onDidChangeTextEditorVisibleRanges((event) => {
+            provider.handleEditorVisibleRangeChange(event.textEditor);
+        })
+    );
+
     // Listen for document changes with debounce
     context.subscriptions.push(
         vscode.workspace.onDidChangeTextDocument((event) => {
@@ -132,6 +140,10 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.workspace.onDidChangeConfiguration((event) => {
             if (event.affectsConfiguration('markdownPreviewInExtensionPanel.defaultZoomLevel')) {
                 provider.onConfigurationChanged();
+            }
+            // Re-render so the webview picks up the new scrollSync flag.
+            if (event.affectsConfiguration('markdownPreviewInExtensionPanel.scrollSync')) {
+                void provider.refresh();
             }
         })
     );

--- a/src/markdownPreviewProvider.ts
+++ b/src/markdownPreviewProvider.ts
@@ -4,6 +4,7 @@ import hljs from 'highlight.js';
 import * as path from 'path';
 import anchor from 'markdown-it-anchor';
 import { ThemeManager, EffectiveTheme } from './themeManager';
+import { lineToScrollTop, scrollTopToLine } from './scrollSync';
 
 interface MarkdownRenderEnv {
     webview?: vscode.Webview;
@@ -53,6 +54,8 @@ export class MarkdownPreviewProvider implements vscode.WebviewViewProvider {
     private _fileSortOrder: FileSortOrder;
     private _previewHistory: HistoryItem[] = [];
     private readonly _maxHistoryItems = 50;
+    private _suppressEditorSync = false;
+    private _suppressEditorSyncTimer?: ReturnType<typeof setTimeout>;
 
     constructor(
         private readonly _extensionUri: vscode.Uri,
@@ -81,6 +84,17 @@ export class MarkdownPreviewProvider implements vscode.WebviewViewProvider {
         this._md.use(anchor, {
             permalink: false,
             slugify: (s: string) => encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-'))
+        });
+
+        // Tag top-level block elements with their source line so the webview can
+        // map editor scroll position to preview position (and back). See scrollSync.ts.
+        this._md.core.ruler.push('source_line_mapping', (state) => {
+            for (const token of state.tokens) {
+                if (token.level === 0 && token.map) {
+                    token.attrSet('data-source-line', String(token.map[0]));
+                }
+            }
+            return false;
         });
 
         this._theme = this.getInitialTheme();
@@ -206,6 +220,9 @@ export class MarkdownPreviewProvider implements vscode.WebviewViewProvider {
                     break;
                 case 'clearHistory':
                     this.clearHistory();
+                    break;
+                case 'revealLine':
+                    this.revealLineInEditor(message.line);
                     break;
             }
         });
@@ -784,6 +801,60 @@ export class MarkdownPreviewProvider implements vscode.WebviewViewProvider {
         return sortOrder === 'modified' ? 'modified' : 'name';
     }
 
+    private getScrollSyncEnabled(): boolean {
+        const config = vscode.workspace.getConfiguration('markdownPreviewInExtensionPanel');
+        return config.get<boolean>('scrollSync', true);
+    }
+
+    /**
+     * Editor -> Preview. Called when an editor's visible range changes. If the
+     * editor shows the document currently in the preview, push its top visible
+     * line to the webview. Suppressed briefly after we drove the editor from a
+     * preview scroll, to avoid a feedback loop.
+     */
+    public handleEditorVisibleRangeChange(editor: vscode.TextEditor): void {
+        if (!this._view || !this.getScrollSyncEnabled() || this._suppressEditorSync) {
+            return;
+        }
+        if (!this._currentPreviewUri || editor.document.uri.toString() !== this._currentPreviewUri.toString()) {
+            return;
+        }
+        const visible = editor.visibleRanges[0];
+        if (!visible) {
+            return;
+        }
+        this._view.webview.postMessage({ command: 'syncToLine', line: visible.start.line });
+    }
+
+    /**
+     * Preview -> Editor. Reveal the given source line at the top of the editor
+     * showing the previewed document. No-op if that document has no visible
+     * editor. Sets a short suppression window so the resulting visible-range
+     * change does not bounce back to the preview.
+     */
+    private revealLineInEditor(line: number): void {
+        if (!this.getScrollSyncEnabled() || !this._currentPreviewUri) {
+            return;
+        }
+        const uri = this._currentPreviewUri.toString();
+        const editor = vscode.window.visibleTextEditors.find(e => e.document.uri.toString() === uri);
+        if (!editor) {
+            return;
+        }
+        const targetLine = Math.max(0, Math.min(Math.round(line), editor.document.lineCount - 1));
+        this._suppressEditorSync = true;
+        editor.revealRange(
+            new vscode.Range(targetLine, 0, targetLine, 0),
+            vscode.TextEditorRevealType.AtTop
+        );
+        if (this._suppressEditorSyncTimer) {
+            clearTimeout(this._suppressEditorSyncTimer);
+        }
+        this._suppressEditorSyncTimer = setTimeout(() => {
+            this._suppressEditorSync = false;
+        }, 150);
+    }
+
     public async edit(): Promise<void> {
         if (!this._currentPreviewUri) {
             void vscode.window.showInformationMessage('No Markdown preview available to edit.');
@@ -940,6 +1011,9 @@ export class MarkdownPreviewProvider implements vscode.WebviewViewProvider {
         const sidebarActiveTabJson = JSON.stringify(this._sidebarActiveTab);
         const fileSortOrderJson = JSON.stringify(this._fileSortOrder);
         const historyItemsJson = JSON.stringify(historyItems);
+        const scrollSyncEnabledJson = JSON.stringify(this.getScrollSyncEnabled());
+        const lineToScrollTopSrc = lineToScrollTop.toString();
+        const scrollTopToLineSrc = scrollTopToLine.toString();
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -2103,6 +2177,48 @@ export class MarkdownPreviewProvider implements vscode.WebviewViewProvider {
             theme: '${mermaidTheme}'
         });
 
+        // --- Scroll sync (editor <-> preview) ---
+        // The exact same pure functions that are unit tested extension-side,
+        // injected here so the mapping logic has a single source of truth.
+        const lineToScrollTop = ${lineToScrollTopSrc};
+        const scrollTopToLine = ${scrollTopToLineSrc};
+        const scrollSyncEnabled = ${scrollSyncEnabledJson};
+        let suppressScrollSync = false;
+        let suppressScrollSyncTimer = null;
+
+        // Read current block anchors fresh each time, since async-rendered
+        // content (mermaid, images) changes element offsets after load.
+        function collectAnchors() {
+            const els = document.querySelectorAll('.preview-content [data-source-line]');
+            const anchors = [];
+            for (const el of els) {
+                const line = parseInt(el.getAttribute('data-source-line'), 10);
+                if (!isNaN(line)) {
+                    anchors.push({ line: line, offset: el.getBoundingClientRect().top + window.scrollY });
+                }
+            }
+            return anchors;
+        }
+
+        function holdSuppression() {
+            suppressScrollSync = true;
+            if (suppressScrollSyncTimer) clearTimeout(suppressScrollSyncTimer);
+            suppressScrollSyncTimer = setTimeout(() => { suppressScrollSync = false; }, 150);
+        }
+
+        // Preview -> Editor: report the top visible source line as we scroll.
+        let previewScrollTimer = null;
+        window.addEventListener('scroll', () => {
+            if (!scrollSyncEnabled || suppressScrollSync) return;
+            if (previewScrollTimer) clearTimeout(previewScrollTimer);
+            previewScrollTimer = setTimeout(() => {
+                const anchors = collectAnchors();
+                if (anchors.length === 0) return;
+                const line = scrollTopToLine(anchors, window.scrollY);
+                vscode.postMessage({ command: 'revealLine', line: line });
+            }, 50);
+        });
+
         // Handle messages from the extension
         window.addEventListener('message', event => {
             const message = event.data;
@@ -2110,6 +2226,13 @@ export class MarkdownPreviewProvider implements vscode.WebviewViewProvider {
                 window.scrollTo(0, 0);
             } else if (message.command === 'showSearch') {
                 showSearch();
+            } else if (message.command === 'syncToLine') {
+                if (!scrollSyncEnabled) return;
+                const anchors = collectAnchors();
+                if (anchors.length === 0) return;
+                // Editor drove this; suppress the echo back to the editor.
+                holdSuppression();
+                window.scrollTo(0, lineToScrollTop(anchors, message.line));
             }
         });
 

--- a/src/scrollSync.ts
+++ b/src/scrollSync.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure scroll-sync mapping between source line numbers and preview pixel
+ * offsets. No VS Code or DOM dependency — unit tested directly, and the
+ * function source is also injected into the webview (via `.toString()`) so the
+ * exact same logic runs in the browser. Keep these self-contained.
+ */
+
+export interface Anchor {
+    /** Source line number (0-based) where the rendered block starts. */
+    line: number;
+    /** Pixel offset of the block's top within the preview scroll container. */
+    offset: number;
+}
+
+/**
+ * Editor -> Preview: given the anchors (ascending) and a source line, return
+ * the preview scrollTop that aligns that line to the top of the viewport.
+ */
+export function lineToScrollTop(anchors: Anchor[], line: number): number {
+    if (anchors.length === 0) {
+        return 0;
+    }
+    if (line <= anchors[0].line) {
+        return anchors[0].offset;
+    }
+    const last = anchors[anchors.length - 1];
+    if (line >= last.line) {
+        return last.offset;
+    }
+    let prev = anchors[0];
+    for (let i = 1; i < anchors.length; i++) {
+        const next = anchors[i];
+        if (line < next.line) {
+            const span = next.line - prev.line;
+            const ratio = span === 0 ? 0 : (line - prev.line) / span;
+            return prev.offset + ratio * (next.offset - prev.offset);
+        }
+        prev = next;
+    }
+    return last.offset;
+}
+
+/**
+ * Preview -> Editor: given the anchors (ascending) and a preview scrollTop,
+ * return the source line that should be revealed at the top of the editor.
+ */
+export function scrollTopToLine(anchors: Anchor[], scrollTop: number): number {
+    if (anchors.length === 0) {
+        return 0;
+    }
+    if (scrollTop <= anchors[0].offset) {
+        return anchors[0].line;
+    }
+    const last = anchors[anchors.length - 1];
+    if (scrollTop >= last.offset) {
+        return last.line;
+    }
+    let prev = anchors[0];
+    for (let i = 1; i < anchors.length; i++) {
+        const next = anchors[i];
+        if (scrollTop < next.offset) {
+            const span = next.offset - prev.offset;
+            const ratio = span === 0 ? 0 : (scrollTop - prev.offset) / span;
+            return prev.line + ratio * (next.line - prev.line);
+        }
+        prev = next;
+    }
+    return last.line;
+}

--- a/src/test/unit/scrollSync.test.ts
+++ b/src/test/unit/scrollSync.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for the pure scroll-sync mapping functions.
+ * These have no VS Code / DOM dependency and run directly under Mocha.
+ */
+import * as assert from 'assert';
+import { lineToScrollTop, scrollTopToLine, Anchor } from '../../scrollSync';
+
+// Anchors: each rendered block knows its source line and its pixel offset
+// in the preview scroll container. Sorted ascending by both line and offset.
+const anchors: Anchor[] = [
+    { line: 0, offset: 0 },
+    { line: 10, offset: 100 },
+    { line: 20, offset: 400 }, // tall block between line 10 and 20 (e.g. image)
+    { line: 30, offset: 500 },
+];
+
+describe('scrollSync mapping', () => {
+
+    describe('lineToScrollTop (editor -> preview)', () => {
+        it('returns 0 when there are no anchors', () => {
+            assert.strictEqual(lineToScrollTop([], 5), 0);
+        });
+
+        it('clamps to the first anchor offset when the line is before it', () => {
+            assert.strictEqual(lineToScrollTop(anchors, -3), 0);
+        });
+
+        it('returns the exact offset when the line matches an anchor', () => {
+            assert.strictEqual(lineToScrollTop(anchors, 10), 100);
+            assert.strictEqual(lineToScrollTop(anchors, 20), 400);
+        });
+
+        it('interpolates linearly between two anchors', () => {
+            // halfway between line 10 (100px) and line 20 (400px) -> 250px
+            assert.strictEqual(lineToScrollTop(anchors, 15), 250);
+        });
+
+        it('clamps to the last anchor offset when the line is past it', () => {
+            assert.strictEqual(lineToScrollTop(anchors, 999), 500);
+        });
+
+        it('handles a fractional line', () => {
+            // line 12 is 20% from 10->20 -> 100 + 0.2*300 = 160
+            assert.strictEqual(lineToScrollTop(anchors, 12), 160);
+        });
+    });
+
+    describe('scrollTopToLine (preview -> editor)', () => {
+        it('returns 0 when there are no anchors', () => {
+            assert.strictEqual(scrollTopToLine([], 250), 0);
+        });
+
+        it('clamps to the first anchor line when scrollTop is above it', () => {
+            assert.strictEqual(scrollTopToLine(anchors, -50), 0);
+        });
+
+        it('returns the exact line when scrollTop matches an anchor offset', () => {
+            assert.strictEqual(scrollTopToLine(anchors, 100), 10);
+            assert.strictEqual(scrollTopToLine(anchors, 400), 20);
+        });
+
+        it('interpolates linearly between two anchors', () => {
+            // 250px is halfway between 100px (line 10) and 400px (line 20) -> line 15
+            assert.strictEqual(scrollTopToLine(anchors, 250), 15);
+        });
+
+        it('clamps to the last anchor line when scrollTop is past it', () => {
+            assert.strictEqual(scrollTopToLine(anchors, 9999), 30);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds **bidirectional scroll synchronization** between the source Markdown editor and the preview, matching the behavior of VS Code's built-in Markdown preview:

- Scrolling the editor moves the preview to the matching content.
- Scrolling the preview moves the editor to the matching source line.

This makes it much easier to locate the spot you're editing when the editor and preview are placed side by side.

## How it works

- **Source-line anchors:** a small `markdown-it` core rule tags each top-level block with `data-source-line` (its source line) at render time.
- **Mapping:** a pure, unit-tested module (`src/scrollSync.ts`) interpolates between line numbers and pixel offsets in both directions.
- **Editor → Preview:** `onDidChangeTextEditorVisibleRanges` pushes the top visible line to the webview (`syncToLine`).
- **Preview → Editor:** the webview reports its top visible line on scroll (`revealLine`); the extension reveals it via `revealRange(..., AtTop)`.
- **Echo-loop guards** on both sides prevent the editor and preview from fighting each other.
- The exact same mapping functions are injected into the webview (via `.toString()`), so the tested logic is the single source of truth.

## Configuration

New setting `markdownPreviewInExtensionPanel.scrollSync` (boolean, default `true`). The source editor must be visible alongside the preview for sync to apply; when the preview is pinned to a different file, sync is skipped.

## Testing

- 11 new unit tests for the mapping functions (`npm run test:unit`, 36 passing total).
- Manually verified in the Extension Development Host with headings, paragraphs, code fences, images, and Mermaid diagrams, plus the pin scenario and toggling the setting.

Notes:
- Version bumped to 1.1.0 and CHANGELOG/README updated — happy to drop the version bump if you'd rather manage releases separately.
- Includes a short design doc under `docs/` describing the approach; remove if you'd prefer not to carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)